### PR TITLE
Fix issues with this

### DIFF
--- a/lib/nodeTap.js
+++ b/lib/nodeTap.js
@@ -106,7 +106,10 @@ module.exports = function (options, mainCb) {
 
 	function closeProc(proc, cb) {
 		return function() {
-			_.forEach(['close', 'data', 'end', 'error'], proc.removeAllListeners);
+			proc.removeAllListeners('close');
+			proc.removeAllListeners('data');
+			proc.removeAllListeners('end');
+			proc.removeAllListeners('error');
 			if(cb) cb();
 		};
 	}


### PR DESCRIPTION
Newer versions of node don't appreciate calling removeAllListeners without a proper "this." Unrolled the loop and kept it simple.